### PR TITLE
Add deprecation note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-A test suite for adapter plugins.
+> :warning: **THIS SUITE IS NO LONGER THE RECOMMENDED WAY TO TEST ADAPTERS.**
+If you are building and testing a new dbt adapter, please read instead: ["Testing a new adapter"](https://docs.getdbt.com/docs/contributing/testing-a-new-adapter)
 
 ## Installation and use
-
 
 `pip install pytest-dbt-adapter`
 


### PR DESCRIPTION
- Anything else you think we should include here?
- Should we do a final release to PyPi that raises an error &/or downgrades the classifier to "7 - Inactive"? (It doesn't look like we've been using a classifier on this project to date)